### PR TITLE
Update NSObject+MTKObserving.m

### DIFF
--- a/Sources/NSObject+MTKObserving.m
+++ b/Sources/NSObject+MTKObserving.m
@@ -193,7 +193,7 @@
 				
             default:// +3
                 // -someObject:didChangeSomethingFrom:to:
-                objc_msgSend(weakSelf, observationSelector, weakObject, old, new); // Fuck off NSInvocation!
+                ((id (*)(id, SEL, id, id, id)) objc_msgSend)(weakSelf, observationSelector, weakObject, old, new); // Fuck off NSInvocation!
                 break;
         }
 	}];


### PR DESCRIPTION
Xcode 7 is stricter about objc_msgSend, so it should be cast
